### PR TITLE
Arrange explanations.

### DIFF
--- a/http/post-raw-data-to-a-flow.md
+++ b/http/post-raw-data-to-a-flow.md
@@ -41,7 +41,7 @@ have their `Content-Type` set to `text/plain` and access the posted data as `msg
 ### Discussion
 
 When the <code class="node">HTTP In</code> node receives a request with the `Content-Type`
-header set to `text/plain` it makes the body of the available as `msg.payload`:
+header set to `text/plain` it makes the body available as `msg.payload`:
 
 ~~~javascript
 var name = msg.payload;


### PR DESCRIPTION
To arrange explanations amaong
post-form-data-to-a-flow.md,
post-json-data-to-a-flow.md and 
post-raw-data-to-a-flow.md.

> it parses the body of the request and makes the form data available under msg.payload:
> it parses the body of the request and makes the data available under msg.payload:
> it makes the body of the available as msg.payload:

How about removing "of the" in post-raw-data page?
